### PR TITLE
Deal with multiple include folders correctly

### DIFF
--- a/tasks/coffeescript_concat.js
+++ b/tasks/coffeescript_concat.js
@@ -43,7 +43,7 @@ module.exports = function(grunt) {
 
       var include = '';
       if (options.includeFolders && options.includeFolders.length) {
-        include = ' -I ' + options.includeFolders.join(' ');
+        include = ' -I ' + options.includeFolders.join(' -I ');
       }
 
       var optionMaxBuffer = 200 * 1024;


### PR DESCRIPTION
Format should be "-I dir1 -I dir2 -I dir3" rather than "-I dir1 dir2 dir3"
